### PR TITLE
Fix the error for the filename that contains whitespace(s)

### DIFF
--- a/convert_to_webp.py
+++ b/convert_to_webp.py
@@ -52,7 +52,7 @@ def convert_to_webp(image):
             filename, extension = image, image.split('.')[1]
             filename_without_extension = filename.replace(
                     '.{}'.format(extension), '')
-            command = 'cwebp -q {} {} -o {}.webp'.format(
+            command = 'cwebp -q {} "{}" -o "{}.webp"'.format(
             quality, filename, filename_without_extension)
             process = subprocess.Popen(command, stdout=subprocess.PIPE)
             output, error = process.communicate()


### PR DESCRIPTION
- Added double quotes to wrap the strings of input and output filenames while formatting the cwebp command in line 55.